### PR TITLE
Add relative growth plotting to OpenAlex notebook

### DIFF
--- a/OpenAlex_keyword_search.ipynb
+++ b/OpenAlex_keyword_search.ipynb
@@ -10,10 +10,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ matplotlib already installed.\n",
-      "✅ seaborn already installed.\n",
-      "✅ pandas already installed.\n",
-      "✅ requests already installed.\n"
+      "\u2705 matplotlib already installed.\n",
+      "\u2705 seaborn already installed.\n",
+      "\u2705 pandas already installed.\n",
+      "\u2705 requests already installed.\n"
      ]
     }
    ],
@@ -32,10 +32,10 @@
     "\n",
     "for pkg_name, import_name in required_packages.items():\n",
     "    if importlib.util.find_spec(import_name) is None:\n",
-    "        print(f\"📦 Installing {pkg_name}...\")\n",
+    "        print(f\"\ud83d\udce6 Installing {pkg_name}...\")\n",
     "        subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", pkg_name])\n",
     "    else:\n",
-    "        print(f\"✅ {pkg_name} already installed.\")\n",
+    "        print(f\"\u2705 {pkg_name} already installed.\")\n",
     "\n",
     "# Now import all the packages\n",
     "import matplotlib.pyplot as plt\n",
@@ -199,6 +199,29 @@
     "plt.grid(True)\n",
     "plt.tight_layout()\n",
     "\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Calculate relative growth rates indexed to the first year used in the plot\n",
+    "base_year = int(df_long['Year'].min())\n",
+    "base_counts = df_long[df_long['Year'] == base_year].set_index('Keyword')['Count']\n",
+    "df_long['RelativeGrowth'] = df_long.apply(lambda r: r['Count'] / base_counts.get(r['Keyword'], float('nan')), axis=1)\n",
+    "\n",
+    "# Plot the relative growth over time\n",
+    "plt.figure(figsize=(14, 8))\n",
+    "sns.lineplot(data=df_long, x='Year', y='RelativeGrowth', hue='Keyword', style='Keyword')\n",
+    "sns.despine()\n",
+    "plt.title(f'Relative Growth Indexed to {base_year}')\n",
+    "plt.xlabel('Year')\n",
+    "plt.ylabel('Relative Growth (Base Year = 1)')\n",
+    "plt.grid(True)\n",
+    "plt.tight_layout()\n",
     "plt.show()\n"
    ]
   },


### PR DESCRIPTION
## Summary
- add a new code cell in `OpenAlex_keyword_search.ipynb` to compute relative growth rates per keyword based on the first year in the filtered dataset
- plot the relative growth over time
- format the notebook JSON for readability

## Testing
- `python openalex_keyword_search.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python -m py_compile openalex_keyword_search.py scopus_search.py`

------
https://chatgpt.com/codex/tasks/task_e_685017504c94832c998d12d14d63a3c3